### PR TITLE
Fix macOS bundling issue.

### DIFF
--- a/CMakeModules/CompleteBundleOSX.cmake.in
+++ b/CMakeModules/CompleteBundleOSX.cmake.in
@@ -1,8 +1,8 @@
 set(app "${CMAKE_INSTALL_PREFIX}/@EXE@")
 set(weprocess "${app}/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app")
-
-list(APPEND BINS "Contents/Resources/updater")
-list(APPEND BINS "Contents/Resources/@HELPER_NAME@")
+if(HAVE_UPDATER)
+  list(APPEND BINS "Contents/Resources/updater")
+endif(HAVE_UPDATER)
 
 set(args ${app})
 list(APPEND args "-verbose=2")

--- a/CMakeModules/CompleteBundleOSX.cmake.in
+++ b/CMakeModules/CompleteBundleOSX.cmake.in
@@ -16,7 +16,7 @@ set(ENV{DYLD_FRAMEWORK_PATH} @QTROOT@/lib:@DEPENDENCY_ROOT@/lib)
 
 execute_process(
   COMMAND ${CMAKE_COMMAND} -E remove "${app}/Contents/Resources/qt.conf"
-  COMMAND "@QTROOT@/bin/macdeployqt" ${args}
+  COMMAND "@QTROOT@/bin/macdeployqt" ${args} "-dmg"
   WORKING_DIRECTORY "@QTROOT@/bin"
 )
 

--- a/CMakeModules/CompleteBundleOSX.cmake.in
+++ b/CMakeModules/CompleteBundleOSX.cmake.in
@@ -1,8 +1,5 @@
 set(app "${CMAKE_INSTALL_PREFIX}/@EXE@")
 set(weprocess "${app}/Contents/Frameworks/QtWebEngineCore.framework/Versions/Current/Helpers/QtWebEngineProcess.app")
-if(HAVE_UPDATER)
-  list(APPEND BINS "Contents/Resources/updater")
-endif(HAVE_UPDATER)
 
 set(args ${app})
 list(APPEND args "-verbose=2")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -110,6 +110,8 @@ if(APPLE)
   set(RESOURCE_ROOT Resources)
 endif()
 
+add_resources(TARGET ${MAIN_TARGET} SOURCES ${CMAKE_CURRENT_BINARY_DIR}/../dist/ DEST ${RESOURCE_ROOT}/web-client/desktop)
+
 if(NOT APPLE)
   set(rsrc_locations
     ${QTROOT}/resources

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,9 +108,8 @@ endif()
 set(RESOURCE_ROOT .)
 if(APPLE)
   set(RESOURCE_ROOT Resources)
+  add_resources(TARGET ${MAIN_TARGET} SOURCES ${CMAKE_CURRENT_BINARY_DIR}/../dist/ DEST ${RESOURCE_ROOT}/web-client/desktop)
 endif()
-
-add_resources(TARGET ${MAIN_TARGET} SOURCES ${CMAKE_CURRENT_BINARY_DIR}/../dist/ DEST ${RESOURCE_ROOT}/web-client/desktop)
 
 if(NOT APPLE)
   set(rsrc_locations


### PR DESCRIPTION
Fixed the bundling issues for macOS. The build script also generates a dmg (compressing the app to ~150mb) for better distribution.

I followed the same convention as windows and linux builds, which assumes you have to manually download the web interface to build/dist folder. 

The build is set up on GitHub actions (macos-latest, QT 5.15.2) (https://github.com/yxwangcs/jellyfin-media-player/actions/runs/731108323), you can download `bundle.dmg` and verify it working. I didn't test if this breaks anything on other platforms though. 



