### PR TITLE
Fix warnings

### DIFF
--- a/external/qslog/QsLogDestFile.cpp
+++ b/external/qslog/QsLogDestFile.cpp
@@ -141,7 +141,7 @@ void QsLogging::FileDestination::write(const QString& message, Level)
   if (mRotationStrategy->shouldRotate())
     rotate();
 
-  mOutputStream << message << endl;
+  mOutputStream << message << "\n";
   mOutputStream.flush();
 }
 

--- a/src/display/DisplayComponent.cpp
+++ b/src/display/DisplayComponent.cpp
@@ -285,29 +285,29 @@ QString DisplayComponent::debugInformation()
 {
   QString debugInfo;
   QTextStream stream(&debugInfo);
-  stream << "Display" << endl;
+  stream << "Display\n";
 
   if (!m_displayManager)
   {
-    stream << "  (no DisplayManager initialized)" << endl;
+    stream << "  (no DisplayManager initialized)\n";
   }
   else
   {
     int display = getApplicationDisplay(true);
     int mode = display < 0 ? -1 : m_displayManager->getCurrentDisplayMode(display);
 
-    stream << "  Current screen: " << displayName(display) << endl;
+    stream << "  Current screen: " << displayName(display) << "\n";
     if (display >= 0)
-      stream << "  Current mode: " << modePretty(display, mode) << endl;
+      stream << "  Current mode: " << modePretty(display, mode) << "\n";
     if (m_displayManager->isValidDisplayMode(m_lastDisplay, m_lastVideoMode))
     {
-      stream << "  Switch back on screen: " << displayName(m_lastDisplay) << endl;
-      stream << "  Switch back to mode: " << modePretty(m_lastDisplay, m_lastVideoMode) << endl;
+      stream << "  Switch back on screen: " << displayName(m_lastDisplay) << "\n";
+      stream << "  Switch back to mode: " << modePretty(m_lastDisplay, m_lastVideoMode) << "\n";
     }
   }
 
-  stream << endl;
-  stream << flush;
+  stream << "\n";
+  stream.flush();
   return debugInfo;
 }
 

--- a/src/display/x11/DisplayManagerX11.cpp
+++ b/src/display/x11/DisplayManagerX11.cpp
@@ -192,8 +192,8 @@ int DisplayManagerX11::getDisplayFromPoint(int x, int y)
       goto done;
 
     matches = x >= crtc->x && y >= crtc->y &&
-              x < crtc->x + crtc->width &&
-              y < crtc->y + crtc->height;
+              x < crtc->x + (int)crtc->width &&
+              y < crtc->y + (int)crtc->height;
 
   done:
     if (crtc)

--- a/src/input/InputComponent.h
+++ b/src/input/InputComponent.h
@@ -7,7 +7,7 @@
 #include <QThread>
 #include <QVariantMap>
 #include <QTimer>
-#include <QTime>
+#include <QElapsedTimer>
 
 #include <functional>
 
@@ -131,7 +131,7 @@ private:
   QStringList m_autoRepeatActions;
 
   QVariantMap m_currentLongPressAction;
-  QTime m_longHoldTimer;
+  QElapsedTimer m_longHoldTimer;
 };
 
 #endif // INPUTADAPTER_H

--- a/src/input/InputRoku.cpp
+++ b/src/input/InputRoku.cpp
@@ -85,7 +85,7 @@ QByteArray InputRoku::getSSDPPacket(const QHostAddress& sender)
   packetData.append("Server: Roku UPnP/1.0 MiniUPnPd/1.4\r\n");
 
   packetData.append("Location: http://");
-  packetData.append(sender.toString());
+  packetData.append(sender.toString().toUtf8());
   packetData.append(":8060/\r\n");
 
   packetData.append("USN: uuid:roku:ecp:");

--- a/src/player/CodecsComponent.h
+++ b/src/player/CodecsComponent.h
@@ -10,7 +10,7 @@
 #include <QQueue>
 #include <QUrl>
 #include <QVariant>
-#include <QTime>
+#include <QElapsedTimer>
 #include <QSet>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -89,7 +89,7 @@ private:
   QNetworkAccessManager m_WebCtrl;
   QByteArray m_DownloadedData;
   QVariant m_userData;
-  QTime m_currentStartTime;
+  QElapsedTimer m_currentStartTime;
   int m_lastProgress;
 };
 

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -1491,74 +1491,74 @@ QString PlayerComponent::videoInformation() const
   if (mpv::qt::get_property(m_mpv, "idle-active").toBool())
     return "";
 
-  info << "File:" << endl;
-  info << "URL: " << MPV_PROPERTY("path") << endl;
-  info << "Container: " << MPV_PROPERTY("file-format") << endl;
+  info << "File:\n";
+  info << "URL: " << MPV_PROPERTY("path") << "\n";
+  info << "Container: " << MPV_PROPERTY("file-format") << "\n";
   info << "Native seeking: " << ((MPV_PROPERTY_BOOL("seekable") &&
                                   !MPV_PROPERTY_BOOL("partially-seekable"))
-                                 ? "yes" : "no") << endl;
-  info << endl;
-  info << "Video:" << endl;
-  info << "Codec: " << MPV_PROPERTY("video-codec") << endl;
+                                 ? "yes" : "no") << "\n";
+  info << "\n";
+  info << "Video:\n";
+  info << "Codec: " << MPV_PROPERTY("video-codec") << "\n";
   info << "Size: " << MPV_PROPERTY("video-params/dw") << "x"
-                   << MPV_PROPERTY("video-params/dh") << endl;
-  info << "FPS (container): " << MPV_PROPERTY("container-fps") << endl;
-  info << "FPS (filters): " << MPV_PROPERTY("estimated-vf-fps") << endl;
-  info << "Aspect: " << MPV_PROPERTY("video-aspect") << endl;
-  info << "Bitrate: " << MPV_PROPERTY("video-bitrate") << endl;
+                   << MPV_PROPERTY("video-params/dh") << "\n";
+  info << "FPS (container): " << MPV_PROPERTY("container-fps") << "\n";
+  info << "FPS (filters): " << MPV_PROPERTY("estimated-vf-fps") << "\n";
+  info << "Aspect: " << MPV_PROPERTY("video-aspect") << "\n";
+  info << "Bitrate: " << MPV_PROPERTY("video-bitrate") << "\n";
   double displayFps = DisplayComponent::Get().currentRefreshRate();
   info << "Display FPS: " << MPV_PROPERTY("display-fps")
-                          << " (" << displayFps << ")" << endl;
+                          << " (" << displayFps << ")" << "\n";
   info << "Hardware Decoding: " << MPV_PROPERTY("hwdec-current")
-                                << " (" << MPV_PROPERTY("hwdec-interop") << ")" << endl;
-  info << endl;
-  info << "Audio: " << endl;
-  info << "Codec: " << MPV_PROPERTY("audio-codec") << endl;
-  info << "Bitrate: " << MPV_PROPERTY("audio-bitrate") << endl;
+                                << " (" << MPV_PROPERTY("hwdec-interop") << ")\n";
+  info << "\n";
+  info << "Audio:\n";
+  info << "Codec: " << MPV_PROPERTY("audio-codec") << "\n";
+  info << "Bitrate: " << MPV_PROPERTY("audio-bitrate") << "\n";
   info << "Channels: ";
   appendAudioFormat(info, "audio-params");
   info << " -> ";
   appendAudioFormat(info, "audio-out-params");
-  info << endl;
-  info << "Output driver: " << MPV_PROPERTY("current-ao") << endl;
-  info << endl;
-  info << "Performance: " << endl;
-  info << "A/V: " << MPV_PROPERTY("avsync") << endl;
-  info << "Dropped frames: " << MPV_PROPERTY("vo-drop-frame-count") << endl;
+  info << "\n";
+  info << "Output driver: " << MPV_PROPERTY("current-ao") << "\n";
+  info << "\n";
+  info << "Performance:\n";
+  info << "A/V: " << MPV_PROPERTY("avsync") << "\n";
+  info << "Dropped frames: " << MPV_PROPERTY("vo-drop-frame-count") << "\n";
   bool dispSync = MPV_PROPERTY_BOOL("display-sync-active");
   info << "Display Sync: ";
   if (!dispSync)
   {
-     info << "no" << endl;
+     info << "no\n";
   }
   else
   {
-    info << "yes (ratio " << MPV_PROPERTY("vsync-ratio") << ")" << endl;
+    info << "yes (ratio " << MPV_PROPERTY("vsync-ratio") << ")\n";
     info << "Mistimed frames: " << MPV_PROPERTY("mistimed-frame-count")
-                                << "/" << MPV_PROPERTY("vo-delayed-frame-count") << endl;
+                                << "/" << MPV_PROPERTY("vo-delayed-frame-count") << "\n";
     info << "Measured FPS: " << MPV_PROPERTY("estimated-display-fps")
-                             << " (" << MPV_PROPERTY("vsync-jitter") << ")" << endl;
-    info << "V. speed corr.: " << MPV_PROPERTY("video-speed-correction") << endl;
-    info << "A. speed corr.: " << MPV_PROPERTY("audio-speed-correction") << endl;
+                             << " (" << MPV_PROPERTY("vsync-jitter") << ")\n";
+    info << "V. speed corr.: " << MPV_PROPERTY("video-speed-correction") << "\n";
+    info << "A. speed corr.: " << MPV_PROPERTY("audio-speed-correction") << "\n";
   }
-  info << endl;
-  info << "Cache:" << endl;
-  info << "Seconds: " << MPV_PROPERTY("demuxer-cache-duration") << endl;
-  info << "Extra readahead: " << MPV_PROPERTY("cache-used") << endl;
-  info << "Buffering: " << MPV_PROPERTY("cache-buffering-state") << endl;
-  info << "Speed: " << MPV_PROPERTY("cache-speed") << endl;
-  info << endl;
-  info << "Misc: " << endl;
+  info << "\n";
+  info << "Cache:\n";
+  info << "Seconds: " << MPV_PROPERTY("demuxer-cache-duration") << "\n";
+  info << "Extra readahead: " << MPV_PROPERTY("cache-used") << "\n";
+  info << "Buffering: " << MPV_PROPERTY("cache-buffering-state") << "\n";
+  info << "Speed: " << MPV_PROPERTY("cache-speed") << "\n";
+  info << "\n";
+  info << "Misc:\n";
   info << "Time: " << MPV_PROPERTY("playback-time") << " / "
                    << MPV_PROPERTY("duration")
-                   << " (" << MPV_PROPERTY("percent-pos") << "%)" << endl;
+                   << " (" << MPV_PROPERTY("percent-pos") << "%)\n";
   info << "State: " << (MPV_PROPERTY_BOOL("pause") ? "paused " : "")
                     << (MPV_PROPERTY_BOOL("paused-for-cache") ? "buffering " : "")
                     << (MPV_PROPERTY_BOOL("core-idle") ? "waiting " : "playing ")
                     << (MPV_PROPERTY_BOOL("seeking") ? "seeking " : "")
-                    << endl;
+                    << "\n";
 
-  info << flush;
+  info.flush();
   return infoStr;
 }
 

--- a/src/system/SystemComponent.cpp
+++ b/src/system/SystemComponent.cpp
@@ -223,29 +223,29 @@ QString SystemComponent::debugInformation()
   QString debugInfo;
   QTextStream stream(&debugInfo);
 
-  stream << "Jellyfin Media Player" << endl;
-  stream << "  Version: " << Version::GetVersionString() << " built: " << Version::GetBuildDate() << endl;
-  stream << "  Web Client Version: " << Version::GetWebVersion() << endl;
-  stream << "  Web Client URL: " << SettingsComponent::Get().value(SETTINGS_SECTION_PATH, "startupurl").toString() << endl;
-  stream << "  Platform: " << getPlatformTypeString() << "-" << getPlatformArchString() << endl;
-  stream << "  User-Agent: " << getUserAgent() << endl;
-  stream << "  Qt version: " << qVersion() << QString("(%1)").arg(Version::GetQtDepsVersion()) << endl;
-  stream << "  Depends version: " << Version::GetDependenciesVersion() << endl;
-  stream << endl;
+  stream << "Jellyfin Media Player\n";
+  stream << "  Version: " << Version::GetVersionString() << " built: " << Version::GetBuildDate() << "\n";
+  stream << "  Web Client Version: " << Version::GetWebVersion() << "\n";
+  stream << "  Web Client URL: " << SettingsComponent::Get().value(SETTINGS_SECTION_PATH, "startupurl").toString() << "\n";
+  stream << "  Platform: " << getPlatformTypeString() << "-" << getPlatformArchString() << "\n";
+  stream << "  User-Agent: " << getUserAgent() << "\n";
+  stream << "  Qt version: " << qVersion() << QString("(%1)").arg(Version::GetQtDepsVersion()) << "\n";
+  stream << "  Depends version: " << Version::GetDependenciesVersion() << "\n";
+  stream << "\n";
 
-  stream << "Files" << endl;
-  stream << "  Log file: " << Paths::logDir(Names::MainName() + ".log") << endl;
-  stream << "  Config file: " << Paths::dataDir(Names::MainName() + ".conf") << endl;
-  stream << endl;
+  stream << "Files\n";
+  stream << "  Log file: " << Paths::logDir(Names::MainName() + ".log") << "\n";
+  stream << "  Config file: " << Paths::dataDir(Names::MainName() + ".conf") << "\n";
+  stream << "\n";
 
-  stream << "Network Addresses" << endl;
+  stream << "Network Addresses\n";
   for(const QString& addr : networkAddresses())
   {
-    stream << "  " << addr << endl;
+    stream << "  " << addr << "\n";
   }
-  stream << endl;
+  stream << "\n";
 
-  stream << flush;
+  stream.flush();
   return debugInfo;
 }
 

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -88,7 +88,7 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   }
 #endif
 
-  QRect loadedGeo = loadGeometry();
+  loadGeometry();
 
   connect(SettingsComponent::Get().getSection(SETTINGS_SECTION_MAIN), &SettingsSection::valuesUpdated,
           this, &KonvergoWindow::updateMainSectionSettings);


### PR DESCRIPTION
This leaves me with only the following QT related warnings for QT 5.15 (which there is no good way of fixing afaik before the minimum QT version can be raised):

```
jellyfin-media-player/src/input/InputLIRC.cpp: In member function ‘void InputLIRC::read(int)’:
jellyfin-media-player/src/input/InputLIRC.cpp:92:67: warning: ‘QStringList QString::split(QChar, QString::SplitBehavior, Qt::CaseSensitivity) const’ is deprecated: Use Qt::SplitBehavior variant instead [-Wdeprecated-declarations]
   92 |     QStringList cmdList = input.split(' ', QString::KeepEmptyParts);
      |                                                                   ^
In file included from /usr/include/qt/QtCore/qcoreapplication.h:44,
                 from /usr/include/qt/QtGui/qguiapplication.h:44,
                 from /usr/include/qt/QtGui/QGuiApplication:1,
                 from /home/eu/src/jellyfin-media-player/src/input/InputLIRC.cpp:2:
/usr/include/qt/QtCore/qstring.h:615:17: note: declared here
  615 |     QStringList split(QChar sep, SplitBehavior behavior,
      |                 ^~~~~
```