### PR TITLE
Fix trailing slash when adding server causes connection faliure.

### DIFF
--- a/native/find-webclient.js
+++ b/native/find-webclient.js
@@ -5,6 +5,7 @@ async function tryConnect(server) {
         if (!server.startsWith("http")) {
             server = "http://" + server;
         }
+        server = server.replace(/\/+$/, "");
 
         const url = new URL("/System/Info/Public", server);
         const response = await fetch(url);


### PR DESCRIPTION
Resolves #280.

This addresses the trailing slash when initially connecting to a first server. 
Adding a second server goes through the web client, which was fixed here https://github.com/jellyfin/jellyfin-web/pull/5205 (will get added into the next release)