### PR TITLE
Fix desktop icon

### DIFF
--- a/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
+++ b/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
@@ -6,7 +6,7 @@ Exec=jellyfinmediaplayer
 Icon=com.github.iwalton3.jellyfin-media-player
 Terminal=false
 Type=Application
-StartupWMClass=com.github.iwalton3.jellyfin-media-player
+StartupWMClass=jellyfinmediaplayer
 Categories=AudioVideo;Video;Player;TV;
 
 Actions=DesktopF;DesktopW;TVF;TVW


### PR DESCRIPTION
Fix desktop icon.  Currently when JMP is docked/favorited and then launched it will spawn a separate icon.  Setting the StartupWMClass to jellyfinmediaplayer resolves this.

Credit goes to this user on the forum.

https://forum.jellyfin.org/t-desktop-entry-icon-bug-on-linux-client