### PR TITLE
Update StartupWMClass for jellyfinmediaplayer

### DIFF
--- a/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
+++ b/resources/meta/com.github.iwalton3.jellyfin-media-player.desktop
@@ -6,7 +6,7 @@ Exec=jellyfinmediaplayer
 Icon=com.github.iwalton3.jellyfin-media-player
 Terminal=false
 Type=Application
-StartupWMClass=com.github.iwalton3.jellyfin-media-player
+StartupWMClass=jellyfinmediaplayer
 Categories=AudioVideo;Video;Player;TV;
 
 Actions=DesktopF;DesktopW;TVF;TVW


### PR DESCRIPTION
Fixing icon display in application bar in gnome

<img width="452" height="264" alt="Captura de tela de 2025-10-16 16-24-14" src="https://github.com/user-attachments/assets/717678b3-0309-4653-b087-ecd50f8e91fc" />