### PR TITLE
QT6: Set storage name for WebEngine profile

### DIFF
--- a/src/ui/webview.qml
+++ b/src/ui/webview.qml
@@ -159,6 +159,7 @@ KonvergoWindow
     height: mainWindow.height
     profile.persistentCookiesPolicy: WebEngineProfile.AllowPersistentCookies
     profile.offTheRecord: false
+    profile.storageName: "JellyfinMediaPlayerStorage"
 
     Component.onCompleted:
     {


### PR DESCRIPTION
QT6 now requires setting a storage name for the profile to keep it persistent