### PR TITLE
Fix command substitution syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ cd mpv-build
 ./use-mpv-release
 ./update
 echo -Dlibmpv=true > mpv_options
-./rebuild -j`nproc`
+./rebuild -j$(nproc)
 sudo ./install
 sudo ln -s /usr/local/lib/x86_64-linux-gnu/libmpv.so /usr/local/lib/x86_64-linux-gnu/libmpv.so.1
 sudo ln -sf /usr/local/lib/x86_64-linux-gnu/libmpv.so /usr/local/lib/libmpv.so.2


### PR DESCRIPTION
Using backticks for command substitution is not supported in all shells, in my case fish. Using `$(foo)` is the POSIX standard, thus ought to be supported in all shells.

~~Also note that I'm not adding myself to `contributors.md`, as I believe this change is trivial enough that it's not warranted.~~ That's for a different repo evidently, so ig it's not needed.