### PR TITLE
Fix issue #875 - Change bundled libmpv-2.dll version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,7 +98,7 @@ jobs:
         curl -L https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip > ninja.zip
         unzip ninja.zip
         mv ninja.exe build/
-        curl -L https://sourceforge.net/projects/mpv-player-windows/files/libmpv/mpv-dev-x86_64-20240304-git-9ac791c.7z/download > mpv.7z
+        curl -L https://sourceforge.net/projects/mpv-player-windows/files/libmpv/mpv-dev-x86_64-v3-20240414-git-6a8b130.7z/download > mpv.7z
         7z x mpv.7z
         mkdir mpv
         mv include mpv


### PR DESCRIPTION
This changes the bundled dll to a version that solves the issue reported in issue #875 