### PR TITLE
Fix startup crash on MacOS when setting custom MPV configuration

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -1478,6 +1478,8 @@ void PlayerComponent::setVideoConfiguration()
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void PlayerComponent::setOtherConfiguration()
 {
+  if (!m_mpv) return;
+
   QString otherConfiguration = SettingsComponent::Get().value(SETTINGS_SECTION_OTHER, "other_conf").toString();
   qDebug() << "Parsing other configuration: "+otherConfiguration;
   QStringList configurationList = otherConfiguration.split(QRegularExpression("[\r\n]"), Qt::SkipEmptyParts);


### PR DESCRIPTION
Fixes a bunch of duplicate issues: https://github.com/jellyfin/jellyfin-desktop/issues?q=macos%20crash%20mpv
#1058, #895, #834, #809, #777

I don't code with C++, so I'm not sure if this is the way to go around fixing this issue, but from my small amount of testing this works and doesn't crash when starting Jellyfin Desktop. It also achieves the desired result of setting the custom MPV configuration from my testing. It would be great to have this merged before the release of 2.0.0!