### PR TITLE
Close to system tray option on Windows

### DIFF
--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -164,6 +164,12 @@
         "platforms": [ "windows" ]
       },
       {
+        "value": "enableWindowsTrayIcon",
+        "display_name": "Enable Windows System Tray",
+        "default": false,
+        "platforms": [ "windows" ]
+      },
+      {
         "value": "enableMPV",
         "display_name": "Enable MPV Player",
         "help": "Enables MPV player for video and audio playback. When disabled, Jellyfin will fall back to the browser's built-in HTML5 player. This setting requires an application restart to take effect.\n\nNote: Disabling MPV will lose advanced features like audio passthrough, hardware decoding options, and codec-specific settings.",

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -21,6 +21,11 @@
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 SettingsComponent::SettingsComponent(QObject *parent) : ComponentBase(parent), m_settingsVersion(-1)
 {
+  connect(this, &SettingsComponent::sectionValueUpdate, this, [this](const QString& section, const QVariantMap& values)
+  {
+    if (section == SETTINGS_SECTION_MAIN && values.contains("enableWindowsTrayIcon"))
+      emit windowsTrayIconChanged();
+  });
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -788,6 +793,12 @@ bool SettingsComponent::autodetectCertBundle()
 bool SettingsComponent::allowBrowserZoom()
 {
   return SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "allowBrowserZoom").toBool();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+bool SettingsComponent::enableWindowsTrayIcon()
+{
+  return SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "enableWindowsTrayIcon").toBool();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/settings/SettingsComponent.h
+++ b/src/settings/SettingsComponent.h
@@ -31,6 +31,7 @@ class SettingsSection;
 class SettingsComponent : public ComponentBase
 {
   Q_OBJECT
+  Q_PROPERTY(bool windowsTrayIcon READ enableWindowsTrayIcon NOTIFY windowsTrayIconChanged)
   DEFINE_SINGLETON(SettingsComponent);
 
 public:
@@ -67,6 +68,7 @@ public:
   Q_INVOKABLE bool autodetectCertBundle();
   Q_INVOKABLE QString detectCertBundlePath();
   Q_INVOKABLE bool allowBrowserZoom();
+  bool enableWindowsTrayIcon();
 
   // host commands
   Q_SLOT Q_INVOKABLE void cycleSettingCommand(const QString& args);
@@ -86,6 +88,9 @@ public:
   // map values. Settings which are part of the section, but did not change, are not
   // part of the map.
   Q_SIGNAL void sectionValueUpdate(const QString& section, const QVariantMap& values);
+
+  // Windows system tray icon enabled/disabled.
+  Q_SIGNAL void windowsTrayIconChanged();
 
   // A hack to load a value from the config file at very early init time, before
   // the SettingsComponent is created.


### PR DESCRIPTION
Displays a system tray icon when enabled. Closing the window (clicking the X or Alt+F4) hides the window.

The window can be restored by clicking the icon, or via its context menu. The application can be quit via the context menu or Ctrl+Q.

Default: Disabled

Closes #470