### PR TITLE
Update dev README with QML logging instructions

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -17,3 +17,11 @@ To get browser devtools, use remote debugging:
 1. Run with `--remote-debugging-port=9222`
 2. Open Chromium/Chrome and navigate to `chrome://inspect/#devices`
 3. Make sure "Discover Network Targets" is checked and `localhost:9222` is configured
+
+## QML Logging
+
+The `console.log()` statements in QML are not printed to the console by default. The simplest workaround for this is to add the following command line argument:
+
+`--log-level debug`
+
+For Qt Creator users, click Projects in the left sidebar, select the "Run Settings" tab, and paste that into the "Command line arguments" text field.


### PR DESCRIPTION
Clarifies how to get Jellyfin's logging system to print out QML logs for developers.