### PR TITLE
Add buffer stats to player seeker and playback info

### DIFF
--- a/src/player/PlayerComponent.h
+++ b/src/player/PlayerComponent.h
@@ -126,6 +126,10 @@ public:
   Q_INVOKABLE QString getCurrentWebPlaylistItemId() const;
   Q_INVOKABLE void setWebPlaylist(const QVariantList& playlist, const QString& currentItemId);
 
+  // Buffer display API - returns JSON strings to avoid WebChannel serialization issues
+  Q_INVOKABLE QString getBufferedRangesJson() const;
+  Q_INVOKABLE QString getBufferStatsJson() const;
+
   QRect videoRectangle() { return m_videoRectangle; }
 
   AlbumArtProvider* albumArtProvider() const { return m_albumArtProvider; }
@@ -274,6 +278,11 @@ private:
   QVariantList m_queuedItems;
 
   AlbumArtProvider* m_albumArtProvider;
+
+  // Buffer display state
+  QVariantList m_bufferedRanges;  // List of {start, end} in milliseconds
+  qint64 m_currentPosition;       // Cached position for buffer calculations
+  qint64 m_duration;              // Cached duration for max forward buffer
 };
 
 #endif // PLAYERCOMPONENT_H


### PR DESCRIPTION
Hey there, first time contributor here! 👋🏼

I've run into the same issue as #560 and tried to tackle it.

I've run into some issues with the async nature of Qt WebChannel and Q_INVOKABLE not supporting complex types. Therefore I settled for JSON based data structure.
The second issue I've ran into was on the JS side, where `getBufferedRanges` is expected to be sync, so I've implemented a caching based approach with a periodic update (1s).

This has been running fine for me on MacOS and Linux (Ubuntu 24.04). Don't have a Windows machine so I could not test this.

<img width="638" height="1027" alt="Screenshot 2026-02-26 at 11 31 52" src="https://github.com/user-attachments/assets/29478e09-f18a-4945-a5d2-d3924004319b" />

For transparency: I did use Cursor with AI support for this, but manually reviewed and adjusted the parts. I also extensively tested the changes with multiple file formats, network states and trancoding