### PR TITLE
Fall back to the first audio track when DefaultAudioStreamIndex is undefined

### DIFF
--- a/native/mpvVideoPlayer.js
+++ b/native/mpvVideoPlayer.js
@@ -318,7 +318,7 @@
                 // Handle audio
                 const audioRelIndex = this._audioTrackIndexToSetOnPlaying != null && this._audioTrackIndexToSetOnPlaying >= 0
                     ? this.getRelativeIndexByType(streams, this._audioTrackIndexToSetOnPlaying, 'Audio')
-                    : -1;
+                    : 1;
 
                 // Handle subtitle - check for external first
                 let subtitleParam;


### PR DESCRIPTION
Live TV omits audioStreamIndex causing DefaultAudioStreamIndex to be undefined, which previously mapped to -1 and disabled audio in the MPV backend. Fall back to the first embedded audio track so Live TV plays with audio.

This fixes issue #1098.