### PR TITLE
Add action for escape -> exit fullscreen

### DIFF
--- a/src/ui/webview.qml
+++ b/src/ui/webview.qml
@@ -98,6 +98,13 @@ Window
 
   Action
   {
+    enabled: mainWindow.webDesktopMode && mainWindow.visibility === Window.FullScreen
+    shortcut: "Escape"
+    onTriggered: mainWindow.setFullScreen(false)
+  }
+
+  Action
+  {
     enabled: mainWindow.webDesktopMode
     shortcut: StandardKey.Close
     onTriggered: mainWindow.close()


### PR DESCRIPTION
Addresses https://github.com/jellyfin/jellyfin-desktop/issues/1056

webview.qml seems to be the place we put desktop keybindings.
I don't know if escape is used for other things, I'm assuming not. I've only tested this on macos