### PR TITLE
Update SystemComponent.cpp

### DIFF
--- a/src/system/SystemComponent.cpp
+++ b/src/system/SystemComponent.cpp
@@ -255,6 +255,8 @@ QString SystemComponent::extractBaseUrl(const QString& url)
 QSslConfiguration SystemComponent::getSSLConfiguration()
 {
   QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+  // Require TLS 1.2 or newer
+  sslConfig.setProtocol(QSsl::TlsV1_2OrLater);
   if (SettingsComponent::Get().ignoreSSLErrors()) {
     sslConfig.setPeerVerifyMode(QSslSocket::VerifyNone);
   } else if (SettingsComponent::Get().autodetectCertBundle()) {


### PR DESCRIPTION
Summary

Enforce a minimum of TLS v1.2 for encrypted connections. This addresses the issue where a QT application continues to use TLS 1.0 even though the underlying Operating System has deprecated it. https://stackoverflow.com/questions/49611168/qt-application-uses-tls1-0