### PR TITLE
Show album art in Windows task bar and MacOS "now playing" controls

### DIFF
--- a/bundle/win/JellyfinDesktop.iss.in
+++ b/bundle/win/JellyfinDesktop.iss.in
@@ -64,8 +64,8 @@ Source: "{#DeployPath}/redist/*.dll"; DestDir: "{app}"; Flags: ignoreversion; Ch
 Source: "{#DeployPath}/vc_redist.x64.exe"; DestDir: "{tmp}"; Flags: ignoreversion deleteafterinstall; Check: ShouldExtractVCRedist
 
 [Icons]
-Name: "{autoprograms}\Jellyfin Desktop"; Filename: "{app}\{#MyAppExeName}"; Comment: "Jellyfin desktop client"; WorkingDir: "{app}"
-Name: "{autodesktop}\Jellyfin Desktop"; Filename: "{app}\{#MyAppExeName}"; Comment: "Jellyfin desktop client"; WorkingDir: "{app}"; Tasks: desktopicon
+Name: "{autoprograms}\Jellyfin Desktop"; Filename: "{app}\{#MyAppExeName}"; Comment: "Jellyfin desktop client"; WorkingDir: "{app}"; AppUserModelID: "org.jellyfin.JellyfinDesktop"
+Name: "{autodesktop}\Jellyfin Desktop"; Filename: "{app}\{#MyAppExeName}"; Comment: "Jellyfin desktop client"; WorkingDir: "{app}"; Tasks: desktopicon; AppUserModelID: "org.jellyfin.JellyfinDesktop"
 
 [Run]
 ; Install VCRedist if downloaded

--- a/native/inputPlugin.js
+++ b/native/inputPlugin.js
@@ -172,7 +172,47 @@ class inputPlugin {
 
                 const state = playbackManager.getPlayerState();
                 if (state && state.NowPlayingItem) {
-                    api.player.notifyMetadata(state.NowPlayingItem);
+                    let apiToken = '';
+                    try {
+                        // Attempt to get API token.
+                        if (window.ApiClient) {
+                            if (typeof window.ApiClient.accessToken === 'function') {
+                                apiToken = window.ApiClient.accessToken() || '';
+                            } else if (window.ApiClient.accessToken) {
+                                apiToken = window.ApiClient.accessToken || '';
+                            } else if (window.ApiClient._serverInfo?.AccessToken) {
+                                apiToken = window.ApiClient._serverInfo.AccessToken;
+                            }
+                        }
+                    } catch (e) {
+                        console.error('inputPlugin: failed to get API token:', e);
+                    }
+                    
+                    // Get server URL
+                    let serverUrl = '';
+                    try {
+                        if (window.ApiClient && typeof window.ApiClient.serverAddress === 'function') {
+                            serverUrl = window.ApiClient.serverAddress() || '';
+                        }
+                    } catch (e) {
+                        console.error('inputPlugin: failed to get serverAddress:', e);
+                    }
+                    if (!serverUrl) {
+                        // Possible backup solution.
+                        serverUrl = window.location.origin;
+                    }
+                    const metadata = Object.assign({}, state.NowPlayingItem, {
+                        _serverUrl: serverUrl,
+                        _apiToken: apiToken
+                    });
+                    try {
+                        if (typeof api.player.notifyServerUrl === 'function') {
+                            api.player.notifyServerUrl(serverUrl);
+                        }
+                    } catch (e) {
+                        console.error('inputPlugin: notifyServerUrl failed:', e);
+                    }
+                    api.player.notifyMetadata(metadata);
 
                     const initialPos = playbackManager.currentTime();
                     if (initialPos !== undefined && initialPos !== null) {

--- a/src/input/apple/InputAppleMediaKeys.h
+++ b/src/input/apple/InputAppleMediaKeys.h
@@ -34,8 +34,11 @@ private:
   GetLocalOriginFunc GetLocalOrigin;
   SetCanBeNowPlayingApplicationFunc SetCanBeNowPlayingApplication;
 
+  void ensureNowPlayingVisibility();
+
   bool m_pendingUpdate;
   quint64 m_currentTime;
+  PlayerComponent::State m_currentState = PlayerComponent::State::finished;
 };
 
 #endif //KONVERGO_INPUTAPPLEMEDIAKEYS_H

--- a/src/input/apple/InputAppleMediaKeys.mm
+++ b/src/input/apple/InputAppleMediaKeys.mm
@@ -90,6 +90,7 @@ bool InputAppleMediaKeys::initInput()
 {
   m_currentTime = 0;
   m_pendingUpdate = false;
+
   m_delegate = [[MediaKeysDelegate alloc] initWithInput:this];
   connect(&PlayerComponent::Get(), &PlayerComponent::stateChanged, this,
           &InputAppleMediaKeys::handleStateChanged);
@@ -98,6 +99,8 @@ bool InputAppleMediaKeys::initInput()
   connect(&PlayerComponent::Get(), &PlayerComponent::updateDuration, this,
           &InputAppleMediaKeys::handleUpdateDuration);
   connect(&PlayerComponent::Get(), &PlayerComponent::onMetaData, this,
+          &InputAppleMediaKeys::handleUpdateMetaData);
+  connect(&PlayerComponent::Get(), &PlayerComponent::metadataChanged, this,
           &InputAppleMediaKeys::handleUpdateMetaData);
 
   // Connect to AlbumArtProvider signals
@@ -145,19 +148,15 @@ static MPNowPlayingPlaybackState convertState(PlayerComponent::State newState)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void InputAppleMediaKeys::handleStateChanged(PlayerComponent::State newState)
 {
-  MPNowPlayingPlaybackState newMPState = convertState(newState);
+  m_currentState = newState;
+
   MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
   NSMutableDictionary *playingInfo = [NSMutableDictionary dictionaryWithDictionary:center.nowPlayingInfo];
   [playingInfo setObject:[NSNumber numberWithDouble:static_cast<double>(m_currentTime) / 1000] forKey:MPNowPlayingInfoPropertyElapsedPlaybackTime];
   center.nowPlayingInfo = playingInfo;
-  [MPNowPlayingInfoCenter defaultCenter].playbackState = newMPState;
-  if (SetNowPlayingVisibility && GetLocalOrigin) {
-    if (newState == PlayerComponent::State::finished || newState == PlayerComponent::State::canceled || newState == PlayerComponent::State::error)
-      SetNowPlayingVisibility(GetLocalOrigin(), MRNowPlayingClientVisibilityNeverVisible);
-    else if (newState == PlayerComponent::State::paused || newState == PlayerComponent::State::playing || newState == PlayerComponent::State::buffering)
-      SetNowPlayingVisibility(GetLocalOrigin(), MRNowPlayingClientVisibilityAlwaysVisible);
-  }
+  center.playbackState = convertState(newState);
 
+  ensureNowPlayingVisibility();
   m_pendingUpdate = true;
 }
 
@@ -217,6 +216,10 @@ void InputAppleMediaKeys::handleUpdateMetaData(const QVariantMap& meta)
   }
 
   MPNowPlayingInfoCenter.defaultCenter.nowPlayingInfo = info;
+  MPNowPlayingInfoCenter.defaultCenter.playbackState = convertState(m_currentState);
+  
+  // This will attempt to update the MacOS "Now Playing" UI.
+  ensureNowPlayingVisibility();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -250,4 +253,22 @@ void InputAppleMediaKeys::handleAlbumArtReady(const QByteArray& imageData)
 void InputAppleMediaKeys::handleAlbumArtUnavailable()
 {
   // No action needed - metadata remains without artwork
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void InputAppleMediaKeys::ensureNowPlayingVisibility()
+{
+  if (!SetNowPlayingVisibility || !GetLocalOrigin) {
+    return;
+  }
+
+  if (m_currentState == PlayerComponent::State::finished ||
+      m_currentState == PlayerComponent::State::canceled ||
+      m_currentState == PlayerComponent::State::error) {
+        SetNowPlayingVisibility(GetLocalOrigin(), MRNowPlayingClientVisibilityNeverVisible);
+    } else if (m_currentState == PlayerComponent::State::paused ||
+           m_currentState == PlayerComponent::State::playing ||
+           m_currentState == PlayerComponent::State::buffering) {
+        SetNowPlayingVisibility(GetLocalOrigin(), MRNowPlayingClientVisibilityAlwaysVisible);
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,10 +38,13 @@
 #include "SignalManager.h"
 #endif
 
-#if defined(Q_OS_WIN) && defined(_M_X64)
+#if defined(Q_OS_WIN)
 #include <windows.h>
+#include <shobjidl.h>
 #include <cstdio>
+#endif
 
+#if defined(Q_OS_WIN) && defined(_M_X64)
 /////////////////////////////////////////////////////////////////////////////////////////
 // Check AVX2 support and swap libmpv DLL if needed (before delay-load triggers)
 // Only relevant for x64 - ARM64 doesn't have AVX2
@@ -441,7 +444,8 @@ int main(int argc, char *argv[])
     QtWebEngineQuick::initialize();
     QApplication app(newArgc, newArgv);
 
-#if defined(Q_OS_WIN) 
+#if defined(Q_OS_WIN)
+    SetCurrentProcessExplicitAppUserModelID(L"org.jellyfin.JellyfinDesktop");
     // Setting window icon on OSX will break user ability to change it
     app.setWindowIcon(QIcon(":/images/icon.png"));
 #endif

--- a/src/player/AlbumArtProvider.cpp
+++ b/src/player/AlbumArtProvider.cpp
@@ -44,6 +44,16 @@ void AlbumArtProvider::requestArtwork(const QVariantMap& metadata, const QUrl& b
     return;
   }
 
+  // Append api_key query parameter for authentication (same method Jellyfin uses for media streams)
+  if (!m_apiToken.isEmpty())
+  {
+    QUrl url(artUrl);
+    QUrlQuery query(url);
+    query.addQueryItem("api_key", m_apiToken);
+    url.setQuery(query);
+    artUrl = url.toString();
+  }
+
   // If already downloading this URL, wait for it
   if (m_pendingReply && m_pendingUrl == artUrl)
     return;
@@ -122,6 +132,11 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
   QString mediaType = metadata.value("MediaType").toString();
   QString itemType = metadata.value("Type").toString();
 
+  // Preserve the base path (e.g. "/stable" for servers behind a reverse proxy subpath)
+  QString basePath = baseUrl.path();
+  if (basePath.endsWith('/'))
+    basePath.chop(1);
+
   QUrl artUrl = baseUrl;
   QUrlQuery query;
 
@@ -134,7 +149,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!albumId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(albumId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(albumId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -150,7 +165,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!itemId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(itemId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(itemId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -167,7 +182,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!seriesId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(seriesId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(seriesId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -182,7 +197,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!seasonId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(seasonId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(seasonId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -198,7 +213,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!itemId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(itemId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(itemId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -216,7 +231,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!itemId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(itemId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(itemId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -231,7 +246,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!itemId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Backdrop/0").arg(itemId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Backdrop/0").arg(itemId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);
@@ -249,7 +264,7 @@ QString AlbumArtProvider::extractArtworkUrl(const QVariantMap& metadata, const Q
 
       if (!itemId.isEmpty() && !imageTag.isEmpty())
       {
-        artUrl.setPath(QString("/Items/%1/Images/Primary").arg(itemId));
+        artUrl.setPath(basePath + QString("/Items/%1/Images/Primary").arg(itemId));
         query.addQueryItem("tag", imageTag);
         query.addQueryItem("maxWidth", "512");
         artUrl.setQuery(query);

--- a/src/player/AlbumArtProvider.h
+++ b/src/player/AlbumArtProvider.h
@@ -19,6 +19,7 @@ public:
   ~AlbumArtProvider() override;
 
   void requestArtwork(const QVariantMap& metadata, const QUrl& baseUrl);
+  void setApiToken(const QString& token) { m_apiToken = token; }
   void cancelPending();
 
 Q_SIGNALS:
@@ -35,6 +36,7 @@ private:
   QNetworkAccessManager* m_networkManager;
   QNetworkReply* m_pendingReply;
   QString m_pendingUrl;
+  QString m_apiToken;
 };
 
 #endif // ALBUMARTPROVIDER_H

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -341,6 +341,10 @@ void PlayerComponent::queueMedia(const QString& url, const QVariantMap& options,
   QUrl jellyfinBaseUrl = qurl.adjusted(QUrl::RemovePath | QUrl::RemoveQuery);
   emit onMetaData(jellyfinMetadata, jellyfinBaseUrl);
 
+  // Store the server base URL for use by notifyMetadata (JS path)
+  if (m_serverBaseUrl.isEmpty())
+    m_serverBaseUrl = jellyfinBaseUrl;
+
   // Request album art from the provider
   if (m_albumArtProvider)
     m_albumArtProvider->requestArtwork(jellyfinMetadata, jellyfinBaseUrl);
@@ -800,7 +804,32 @@ void PlayerComponent::notifySeek(qint64 positionMs)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void PlayerComponent::notifyMetadata(const QVariantMap& metadata)
 {
+  // Extract server URL embedded by JavaScript as a fallback
+  if (metadata.contains("_serverUrl"))
+  {
+    QUrl url(metadata["_serverUrl"].toString());
+    if (!url.isEmpty())
+      m_serverBaseUrl = url;
+  }
+
+  // Extract API token embedded by JavaScript for authenticated artwork requests
+  if (metadata.contains("_apiToken"))
+  {
+    QString token = metadata["_apiToken"].toString();
+    if (!token.isEmpty() && m_albumArtProvider)
+      m_albumArtProvider->setApiToken(token);
+  }
+
   emit metadataChanged(metadata);
+
+  if (m_albumArtProvider && !m_serverBaseUrl.isEmpty())
+    m_albumArtProvider->requestArtwork(metadata, m_serverBaseUrl);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void PlayerComponent::notifyServerUrl(const QString& url)
+{
+  m_serverBaseUrl = QUrl(url);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/player/PlayerComponent.h
+++ b/src/player/PlayerComponent.h
@@ -74,6 +74,7 @@ public:
   Q_INVOKABLE void notifyPosition(qint64 positionMs);
   Q_INVOKABLE void notifySeek(qint64 positionMs);
   Q_INVOKABLE void notifyMetadata(const QVariantMap& metadata);
+  Q_INVOKABLE void notifyServerUrl(const QString& url);
   Q_INVOKABLE void notifyVolumeChange(double volume);
 
   // 0-100 volume 0=mute and 100=normal
@@ -277,6 +278,7 @@ private:
   QTimer* m_playlistTimer;
   QVariantList m_queuedItems;
 
+  QUrl m_serverBaseUrl;
   AlbumArtProvider* m_albumArtProvider;
 };
 

--- a/src/taskbar/TaskbarComponentWin.cpp
+++ b/src/taskbar/TaskbarComponentWin.cpp
@@ -1,6 +1,5 @@
 #include <QApplication>
 #include <QStyle>
-#include <QUrlQuery>
 
 #include <Windows.Foundation.h>
 #include <systemmediatransportcontrolsinterop.h>
@@ -9,9 +8,13 @@
 
 #include "TaskbarComponentWin.h"
 #include "PlayerComponent.h"
+#include "player/AlbumArtProvider.h"
 #include "input/InputComponent.h"
 #include "settings/SettingsComponent.h"
 #include "settings/SettingsSection.h"
+
+#include <robuffer.h>
+#include <Windows.Storage.Streams.h>
 
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Media;
@@ -69,6 +72,15 @@ void TaskbarComponentWin::setWindow(QQuickWindow* window)
   connect(&PlayerComponent::Get(), &PlayerComponent::paused, this, &TaskbarComponentWin::paused);
   connect(&PlayerComponent::Get(), &PlayerComponent::stopped, this, &TaskbarComponentWin::stopped);
   connect(&PlayerComponent::Get(), &PlayerComponent::onMetaData, this, &TaskbarComponentWin::onMetaData);
+  connect(&PlayerComponent::Get(), &PlayerComponent::metadataChanged, this, [this](const QVariantMap& meta) {
+    onMetaData(meta, QUrl());
+  });
+
+  if (PlayerComponent::Get().albumArtProvider())
+  {
+    connect(PlayerComponent::Get().albumArtProvider(), &AlbumArtProvider::artworkReady,
+            this, &TaskbarComponentWin::onAlbumArtReady);
+  }
 
   setControlsVisible(false);
   setPaused(false);
@@ -223,6 +235,8 @@ void TaskbarComponentWin::initializeMediaTransport(HWND hwnd)
     return;
   }
 
+  m_displayUpdater->put_AppMediaId(HStringReference(L"org.jellyfin.JellyfinDesktop").Get());
+
   m_initialized = true;
   qInfo() << "SystemMediaTransportControls successfully initialized";
 }
@@ -243,6 +257,9 @@ void TaskbarComponentWin::onMetaData(const QVariantMap& meta, QUrl baseUrl)
     return;
   }
 
+  // Re-set AppMediaId after ClearAll wipes it
+  m_displayUpdater->put_AppMediaId(HStringReference(L"org.jellyfin.JellyfinDesktop").Get());
+
   if (mediaType == "Video")
   {
     setVideoMeta(meta);
@@ -251,8 +268,6 @@ void TaskbarComponentWin::onMetaData(const QVariantMap& meta, QUrl baseUrl)
   {
     setAudioMeta(meta);
   }
-
-  setThumbnail(meta, baseUrl);
 
   hr = m_displayUpdater->Update();
   if (FAILED(hr))
@@ -348,71 +363,119 @@ void TaskbarComponentWin::setVideoMeta(const QVariantMap& meta)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
-void TaskbarComponentWin::setThumbnail(const QVariantMap& meta, QUrl baseUrl)
+void TaskbarComponentWin::onAlbumArtReady(const QByteArray& imageData)
 {
-  QString imgUrl;
+  if (!m_initialized || !m_displayUpdater)
+    return;
+
   HRESULT hr;
 
-  auto images = meta["ImageTags"].toMap();
-  if (images.contains("Primary"))
+  // Create an InMemoryRandomAccessStream and write the image data into it.
+  ComPtr<ABI::Windows::Storage::Streams::IRandomAccessStream> memStream;
+  hr = ActivateInstance(HStringReference(RuntimeClass_Windows_Storage_Streams_InMemoryRandomAccessStream).Get(),
+                        &memStream);
+  if (FAILED(hr))
   {
-    auto itemId = meta["Id"].toString();
-    auto imgTag = images["Primary"].toString();
-    QUrlQuery query;
-    query.addQueryItem("tag", imgTag);
-    baseUrl.setPath("/Items/" + itemId + "/Images/Primary");
-    baseUrl.setQuery(query);
-    imgUrl = baseUrl.toString();
-  }
-  else if (meta.contains("AlbumId") && meta.contains("AlbumPrimaryImageTag")
-           && meta["AlbumId"].canConvert(QMetaType::QString)
-           && meta["AlbumPrimaryImageTag"].canConvert(QMetaType::QString))
-  {
-    auto itemId = meta["AlbumId"].toString();
-    auto imgTag = meta["AlbumPrimaryImageTag"].toString();
-    QUrlQuery query;
-    query.addQueryItem("tag", imgTag);
-    baseUrl.setPath("/Items/" + itemId + "/Images/Primary");
-    baseUrl.setQuery(query);
-    imgUrl = baseUrl.toString();
-  }
-  else
-  {
-    qDebug() << "No Primary image found. Do nothing";
+    qWarning() << "Failed to create InMemoryRandomAccessStream";
     return;
   }
 
-  
+  // Get the IOutputStream interface to write data.
+  ComPtr<ABI::Windows::Storage::Streams::IOutputStream> outputStream;
+  hr = memStream.As(&outputStream);
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to get IOutputStream from memory stream";
+    return;
+  }
 
+  // Create a DataWriter to write bytes into the stream.
+  ComPtr<ABI::Windows::Storage::Streams::IDataWriter> writer;
+  hr = ActivateInstance(HStringReference(RuntimeClass_Windows_Storage_Streams_DataWriter).Get(), &writer);
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to create DataWriter";
+    return;
+  }
+
+  // Attach the writer to the output stream.
+  ComPtr<ABI::Windows::Storage::Streams::IDataWriterFactory> writerFactory;
+  hr = GetActivationFactory(HStringReference(RuntimeClass_Windows_Storage_Streams_DataWriter).Get(), &writerFactory);
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to get DataWriter factory";
+    return;
+  }
+
+  hr = writerFactory->CreateDataWriter(outputStream.Get(), &writer);
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to create DataWriter with output stream";
+    return;
+  }
+
+  // Write the image bytes.
+  hr = writer->WriteBytes(imageData.size(), (BYTE*)imageData.constData());
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to write image bytes";
+    return;
+  }
+
+  // Flush the writer (synchronously store to stream).
+  ComPtr<ABI::Windows::Foundation::IAsyncOperation<UINT32>> storeOp;
+  hr = writer->StoreAsync(&storeOp);
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to store DataWriter";
+    return;
+  }
+
+  // Despite the name, this "async" operation is entirely in-memory.
+  ComPtr<ABI::Windows::Foundation::IAsyncInfo> asyncInfo;
+  hr = storeOp.As(&asyncInfo);
+  if (SUCCEEDED(hr))
+  {
+    ABI::Windows::Foundation::AsyncStatus status;
+    do {
+      hr = asyncInfo->get_Status(&status);
+    } while (SUCCEEDED(hr) && status == ABI::Windows::Foundation::AsyncStatus::Started);
+
+    if (status != ABI::Windows::Foundation::AsyncStatus::Completed)
+    {
+      qWarning() << "DataWriter store did not complete successfully";
+      return;
+    }
+  }
+
+  UINT32 bytesWritten = 0;
+  storeOp->GetResults(&bytesWritten);
+
+  // Detach the stream from the writer so it doesn't get closed.
+  hr = writer->DetachStream(&outputStream);
+
+  // Seek back to the beginning.
+  hr = memStream->Seek(0);
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to seek memory stream to beginning";
+    return;
+  }
+
+  // Create a RandomAccessStreamReference from the in-memory stream.
   ComPtr<IRandomAccessStreamReferenceStatics> streamRefFactory;
   hr = GetActivationFactory(HStringReference(RuntimeClass_Windows_Storage_Streams_RandomAccessStreamReference).Get(),
     &streamRefFactory);
   if (FAILED(hr))
   {
-    qWarning() << "Failed instantiating stream factory";
+    qWarning() << "Failed to get RandomAccessStreamReference factory";
     return;
   }
 
-  ComPtr<IUriRuntimeClassFactory> uriFactory;
-  hr = GetActivationFactory(HStringReference(RuntimeClass_Windows_Foundation_Uri).Get(), &uriFactory);
+  hr = streamRefFactory->CreateFromStream(memStream.Get(), &m_thumbnail);
   if (FAILED(hr))
   {
-    qWarning() << "Failed instantiating uri factory";
-    return;
-  }
-
-  ComPtr<IUriRuntimeClass> uri;
-  hr = uriFactory->CreateUri(HStringReference((const wchar_t*)imgUrl.utf16()).Get(), &uri);
-  if (FAILED(hr))
-  {
-    qWarning() << "Failed to create uri";
-    return;
-  }
-
-  hr = streamRefFactory->CreateFromUri(uri.Get(), &m_thumbnail);
-  if (FAILED(hr))
-  {
-    qWarning() << "Failed to create stream from uri";
+    qWarning() << "Failed to create stream reference from memory stream";
     return;
   }
 
@@ -422,6 +485,15 @@ void TaskbarComponentWin::setThumbnail(const QVariantMap& meta, QUrl baseUrl)
     qWarning() << "Failed to set thumbnail";
     return;
   }
+
+  hr = m_displayUpdater->Update();
+  if (FAILED(hr))
+  {
+    qWarning() << "Failed to update display after setting thumbnail";
+    return;
+  }
+
+  qDebug() << "Taskbar thumbnail updated from album art (" << bytesWritten << "bytes)";
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/taskbar/TaskbarComponentWin.h
+++ b/src/taskbar/TaskbarComponentWin.h
@@ -26,7 +26,7 @@ private:
   void onMetaData(const QVariantMap &meta, QUrl baseUrl);
   void setAudioMeta(const QVariantMap &meta);
   void setVideoMeta(const QVariantMap &meta);
-  void setThumbnail(const QVariantMap &meta, QUrl baseUrl);
+  void onAlbumArtReady(const QByteArray& imageData);
   void playing();
   void stopped();
   void paused();


### PR DESCRIPTION
Updates controls to fix bugs preventing album art from displaying.

Other fixes in the same widgets:
- Addresses issues preventing app name and logo from appearing on Windows (requires installation)
- Fixes bug where the "Play" button did not always appear on MacOS when media is being played