### PR TITLE
Bring back old debug overlay

### DIFF
--- a/src/ui/WindowManager.cpp
+++ b/src/ui/WindowManager.cpp
@@ -7,12 +7,18 @@
 #include "taskbar/TaskbarComponent.h"
 #include "input/InputComponent.h"
 #include "utils/Utils.h"
+#include "system/SystemComponent.h"
 
 #include <QCursor>
 #include <QEvent>
 #include <QGuiApplication>
 #include <QScreen>
 #include <QDebug>
+#include <QQmlProperty>
+
+#include <QOpenGLContext>
+#include <QOpenGLFunctions>
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 WindowManager& WindowManager::Get()
@@ -142,6 +148,16 @@ void WindowManager::initializeWindow(QQuickWindow* window)
     connect(m_webView, SIGNAL(zoomFactorChanged()), this, SLOT(onZoomFactorChanged()));
     enforceZoom();
   }
+
+  m_infoTimer = new QTimer(this);
+  m_infoTimer->setInterval(1000);
+
+  m_systemDebugInfo = SystemComponent::Get().debugInformation();
+
+  connect(m_infoTimer, &QTimer::timeout, this, &WindowManager::updateDebugInfo);
+  connect(m_window, &QQuickWindow::beforeSynchronizing, this, &WindowManager::updateOpenGLInfo, static_cast<Qt::ConnectionType>(Qt::DirectConnection|Qt::SingleShotConnection));
+
+  QQmlProperty(m_window, "showDebugLayer").connectNotifySignal(this, SLOT(onShowDebugLayerChanged()));
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -879,6 +895,57 @@ void WindowManager::applySettings()
 void WindowManager::onZoomFactorChanged()
 {
   enforceZoom();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void WindowManager::updateDebugInfo()
+{
+  QString debugInfo = m_systemDebugInfo;
+  debugInfo += DisplayComponent::Get().debugInformation();
+  debugInfo += m_openglInfo;
+
+  QString infoString;
+  QDebug info(&infoString);
+  info << "Qt windowing info:\n";
+  info << "  FS: " << m_window->visibility() << "\n";
+  info << "  Geo: " << m_window->geometry() << "\n";
+  for (QScreen* scr : QGuiApplication::screens())
+  {
+    info << "  Screen" << scr->name() << scr->geometry() << "\n";
+  }
+  info << "\n";
+  debugInfo += infoString;
+
+  m_window->setProperty("debugInfo", debugInfo);
+  m_window->setProperty("videoInfo", PlayerComponent::Get().videoInformation());
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void WindowManager::onShowDebugLayerChanged() {
+  if(m_window->property("showDebugLayer").toBool()) {
+    m_infoTimer->start();
+    updateDebugInfo();
+  } else {
+    m_infoTimer->stop();
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void WindowManager::updateOpenGLInfo() {
+  m_openglInfo = "";
+  QOpenGLContext* glctx = QOpenGLContext::currentContext();
+  if (glctx && glctx->isValid())
+  {
+    m_openglInfo += "\nOpenGL:\n";
+    GLenum syms[4] = {GL_VENDOR, GL_RENDERER, GL_VERSION, GL_SHADING_LANGUAGE_VERSION};
+    for (auto sym : syms)
+    {
+      auto s = glctx->functions()->glGetString(sym);
+      if (s)
+        m_openglInfo += QString("  ") + QString::fromUtf8(s) + "\n";
+    }
+    m_openglInfo += "\n";
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ui/WindowManager.h
+++ b/src/ui/WindowManager.h
@@ -69,6 +69,9 @@ private slots:
   void updateWindowState(bool saveGeo = true);
   void saveGeometrySlot();
   void onZoomFactorChanged();
+  void updateDebugInfo();
+  void onShowDebugLayerChanged();
+  void updateOpenGLInfo();
 
 private:
   // Geometry (separate size/position)
@@ -117,6 +120,11 @@ private:
   // initial size tracking to detect if size changed from default
   QSize m_initialSize;
   QSize m_initialScreenSize;
+
+  // debug info
+  QString m_systemDebugInfo;
+  QString m_openglInfo;
+  QTimer* m_infoTimer;
 };
 
 #endif // WINDOWMANAGER_H


### PR DESCRIPTION
In commit c7e9cf7486b883c3a1f363f1f0379a71d2dd1fa0 debug overlay (enabled by pressing ctrl+shift+D) lost it's functionality and it seems like it got forgotten since then.
This PR aims to restore the old debug overlay, as there are still people (me) who actually use it.

Current debug overlay:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/c37a0047-ec05-4a66-a4eb-ac2588ca79a2" />


Old debug overlay:
<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/b7ba238b-e29d-41f3-bfed-b19733b95304" />
