### PR TITLE
Fix build with mpvqt 1.2.0

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -299,39 +299,40 @@ void PlayerComponent::queueMedia(const QString& url, const QVariantMap& options,
   QUrl qurl = url;
   QString host = qurl.host();
 
-  QVariantList command;
+  QStringList command;
   command << "loadfile" << qurl.toString(QUrl::FullyEncoded);
   command << "append-play"; // if nothing is playing, play it now, otherwise just enqueue it
 
 #if MPV_CLIENT_API_VERSION >= MPV_MAKE_VERSION(2, 3)
-  command << -1; // insert_at_idx
+  command << "-1"; // insert_at_idx
 #endif
 
-  QVariantMap extraArgs;
+  QString extraArgs;
 
   quint64 startMilliseconds = options["startMilliseconds"].toLongLong();
   if (startMilliseconds != 0)
-    extraArgs.insert("start", "+" + QString::number(startMilliseconds / 1000.0));
+    extraArgs += "start=+" + QString::number(startMilliseconds / 1000.0) + ",";
 
   // we're going to select these streams later, in the preloaded hook
-  extraArgs.insert("aid", "no");
-  extraArgs.insert("sid", "no");
+  extraArgs += "aid=no,";
+  extraArgs += "sid=no,";
 
   m_currentSubtitleStream = subtitleStream;
   m_currentAudioStream = audioStream;
 
   if (metadata["type"] == "music")
-    extraArgs.insert("vid", "no");
+    extraArgs += "vid=no,";
 
-  extraArgs.insert("pause", options["autoplay"].toBool() ? "no" : "yes");
+  QString pause = options["autoplay"].toBool() ? "no" : "yes";
+  extraArgs += "pause=" + pause + ",";
 
   QString userAgent = metadata["headers"].toMap()["User-Agent"].toString();
   if (userAgent.size())
-    extraArgs.insert("user-agent", userAgent);
+    extraArgs += "user-agent=" + userAgent + ",";
 
   // Make sure the list of requested codecs is reset.
-  extraArgs.insert("ad", "");
-  extraArgs.insert("vd", "");
+  extraArgs += "ad=,";
+  extraArgs += "vd="; // Keep last
 
   command << extraArgs;
 
@@ -850,7 +851,7 @@ void PlayerComponent::seekTo(qint64 ms)
     return;
   }
   double timeSecs = ms / 1000.0;
-  QVariantList args = (QVariantList() << "seek" << timeSecs << "absolute+exact");
+  QStringList args = (QStringList() << "seek" << QString::number(timeSecs) << "absolute+exact");
   m_mpv->command( args);
 }
 


### PR DESCRIPTION
Since [b3dbc4b], command() takes a QStringList instead of a QVariantList. Replace the usage of QVariantList with QStringList for each call of command(), and do not use a QVariantMap to build the extraArgs, instead, we now need to build the option list as a string separated by commas.

It fixes these build errors:


```
/src/src/player/PlayerComponent.cpp: In member function ‘void PlayerComponent::queueMedia(const QString&, const QVariantMap&, const QVariantMap&, const QVariant&, const QVariant&)’:
/src/src/player/PlayerComponent.cpp:338:19: error: cannot convert ‘QVariantList’ {aka ‘QList<QVariant>’} to ‘const QStringList&’ {aka ‘const QList<QString>&’}
  338 |   m_mpv->command( command);
      |                   ^~~~~~~
      |                   |
      |                   QVariantList {aka QList<QVariant>}
In file included from /usr/include/MpvQt/mpvabstractitem.h:10,
                 from /usr/include/MpvQt/MpvAbstractItem:1,
                 from /src/src/player/MpvVideoItem.h:4,
                 from /src/src/player/PlayerComponent.cpp:16:
/usr/include/MpvQt/mpvcontroller.h:165:41: note: initializing argument 1 of ‘QVariant MpvController::command(const QStringList&)’
  165 |     QVariant command(const QStringList &params);
      |                      ~~~~~~~~~~~~~~~~~~~^~~~~~
```


```
/src/src/player/PlayerComponent.cpp: In member function ‘virtual void PlayerComponent::seekTo(qint64)’:
/src/src/player/PlayerComponent.cpp:854:19: error: cannot convert ‘QVariantList’ {aka ‘QList<QVariant>’} to ‘const QStringList&’ {aka ‘const QList<QString>&’}
  854 |   m_mpv->command( args);
      |                   ^~~~
      |                   |
      |                   QVariantList {aka QList<QVariant>}
/usr/include/MpvQt/mpvcontroller.h:165:41: note: initializing argument 1 of ‘QVariant MpvController::command(const QStringList&)’
  165 |     QVariant command(const QStringList &params);
      |                      ~~~~~~~~~~~~~~~~~~~^~~~~~
```

This should fix the current build failures in the CI.

[b3dbc4b]: https://github.com/KDE/mpvqt/commit/b3dbc4b1f51121da81865ca051eaa8f8a63e3f15
