### PR TITLE
Add missing runtime dependency: qml6-module-qt-labs-platform

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,6 +50,7 @@ Depends: ${shlibs:Depends},
          qml6-module-qtquick-controls,
          qml6-module-qtquick-window,
          qml6-module-qtqml-workerscript,
-         qml6-module-qtquick-templates
+         qml6-module-qtquick-templates,
+         qml6-module-qt-labs-platform
 Description: Jellyfin is the Free Software Media System.
  This package provides the Jellyfin desktop media player.


### PR DESCRIPTION
`src/ui/webview.qml` imports [`Qt.labs.platform`](https://github.com/jellyfin/jellyfin-desktop/blob/master/src/ui/webview.qml#L7), a module the app uses at runtime. The `Depends:` list in `debian/control` never included the package that provides it, `qml6-module-qt-labs-platform`.

Verified none of the `qt6-*-dev` build packages (`qt6-base-dev`, `qt6-declarative-dev`, `qt6-webengine-dev`, etc.) pull in `qml6-module-qt-labs-platform` transitively. `apt-cache depends` shows no such dependency, so it has to be listed explicitly.